### PR TITLE
Disable unwanted ssh features

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,8 @@ if [ "${1}" = 'sshd' ]; then
   done
   # Disable unwanted authentications
   sed -i -E -e 's/^#?(\w+Authentication)\s.*/\1 no/' -e 's/^(PubkeyAuthentication) no/\1 yes/' /etc/ssh/sshd_config
+  # Disable sftp subsystem
+  sed -i -E 's/^Subsystem\ssftp\s/#&/' /etc/ssh/sshd_config
 fi
 
 # Fix permissions at every startup

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,8 @@ if [ "${1}" = 'sshd' ]; then
     [ -f $keyfile ] || ssh-keygen -q -N '' -f $keyfile -t $algorithm
     grep -q "HostKey $keyfile" /etc/ssh/sshd_config || echo "HostKey $keyfile" >> /etc/ssh/sshd_config
   done
+  # Disable unwanted authentications
+  sed -i -E -e 's/^#?(\w+Authentication)\s.*/\1 no/' -e 's/^(PubkeyAuthentication) no/\1 yes/' /etc/ssh/sshd_config
 fi
 
 # Fix permissions at every startup


### PR DESCRIPTION
This PR disables all authentications except `PubkeyAuthentication`.

Without this change, a user whose ssh key is not known to gitolite will be prompted for a password when ssh'ing to the gitolite server because `PasswordAuthentication` is being tried.

With this change, the user will get _Permission denied (publickey)._ instead.

Being at it, I also disabled the `sftp` subsystem, which does not make sense for gitolite servers.