### PR TITLE
Update Alpine to 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 # Install OpenSSH server and Gitolite
 # Unlock the automatically-created git user


### PR DESCRIPTION
This updates gitolite from v3.5.0 to v3.6.0:
```bash
$ ssh git@localhost info
hello user, this is git@5b52de295201 running gitolite3 v3.6.0-4851-g7817a6c9e1 on git 2.15.0
```
Gitolite 3.6+ has a nice feature: [repo-specific hooks](http://gitolite.com/gitolite/cookbook/#v36-variation-repo-specific-hooks), which I'd like to use.