### PR TITLE
update base image to alpine:3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.14
 
 # Install OpenSSH server and Gitolite
 # Unlock the automatically-created git user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.18
 
 # Install OpenSSH server and Gitolite
 # Unlock the automatically-created git user


### PR DESCRIPTION
alpine:3.10 is not supported by alpine any more

Closes #13.