### PR TITLE
Send sshd logs to standard out

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # if command is sshd, set it up correctly
 if [ "${1}" = 'sshd' ]; then
-  set -- /usr/sbin/sshd -D
+  set -- /usr/sbin/sshd -D -e
 
   # Setup SSH HostKeys if needed
   for algorithm in rsa dsa ecdsa ed25519


### PR DESCRIPTION
As mentioned in #11, sshd tries to log to rsyslog, which isn't installed in Alpine by default, so this lets the logs be sent to standard out instead, where it can be managed by Docker.

(Opening a PR because I think this would be useful to do by default.  In unlikely event that logs are too verbose / not needed, user could adjust sshd config.)

Fixes #11.