### PR TITLE
Add Podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ Based on Alpine Linux.
 
 ## Quick setup
 
-Create volumes for your SSH server host keys and for your Gitolite config and repositories
+_Where `(docker|podman)` appears below, use either `docker` or `podman` (as appropriate)._
 
-* Docker >= 1.9
+Create volumes for your SSH server host keys and for your Gitolite config and repositories:
+
+* Docker >= 1.13 or Podman
+
+        (docker|podman) volume create gitolite-sshkeys
+        (docker|podman) volume create gitolite-git
+
+* Docker >= 1.9 ('--name' is optional beginning with v1.13)
 
         docker volume create --name gitolite-sshkeys
         docker volume create --name gitolite-git
@@ -19,9 +26,9 @@ Create volumes for your SSH server host keys and for your Gitolite config and re
 
 Setup Gitolite with yourself as the administrator:
 
-* Docker >= 1.10
+* Docker >= 1.10 or Podman
 
-        docker run --rm -e SSH_KEY="$(cat ~/.ssh/id_rsa.pub)" -e SSH_KEY_NAME="$(whoami)" -v gitolite-sshkeys:/etc/ssh/keys -v gitolite-git:/var/lib/git jgiannuzzi/gitolite true
+        (docker|podman) run --rm -e SSH_KEY="$(cat ~/.ssh/id_rsa.pub)" -e SSH_KEY_NAME="$(whoami)" -v gitolite-sshkeys:/etc/ssh/keys -v gitolite-git:/var/lib/git jgiannuzzi/gitolite true
 
 * Docker == 1.9 (There is a bug in `docker run --rm` that removes volumes when removing the container)
 
@@ -41,5 +48,9 @@ Finally run your Gitolite container in the background:
 * Docker < 1.9
 
         docker run -d --name gitolite -p 22:22 --volumes-from gitolite-data jgiannuzzi/gitolite
+
+* Podman
+
+        podman run -d --name gitolite -p 22:22 -v gitolite-sshkeys:/etc/ssh/keys -v gitolite-git:/var/lib/git:exec jgiannuzzi/gitolite
 
 You can then add users and repos by following the [official guide](https://github.com/sitaramc/gitolite#adding-users-and-repos).


### PR DESCRIPTION
Podman does not allow the '--name' switch during volume creation. Beginning with Docker 1.13, the '--name' switch became [optional](https://docs.docker.com/engine/release-notes/prior-releases/#remote-api-v125--client). README.md was updated to provide compatible instructions for both Docker and Podman.